### PR TITLE
修正了文档示例代码中预测的报错问题

### DIFF
--- a/docs/source/get_started/run_on_gpu.rst
+++ b/docs/source/get_started/run_on_gpu.rst
@@ -142,14 +142,14 @@ See `Get Started <../get_started/get_started.html>`_ to get more details.
     import numpy as np
 
     from paddlets.datasets.repository import get_dataset
-    from paddlets.transform.normalization import StandardScaler
+    from paddlets.transform.sklearn_transforms import StandardScaler
     from paddlets.models.forecasting import MLPRegressor
 
     np.random.seed(2022)
 
     # prepare data
     tsdataset = get_dataset("WTH")
-    ts_train, ts_val_test = ts.split("2012-03-31 23:00:00")
+    ts_train, ts_val_test = tsdataset.split("2012-03-31 23:00:00")
     ts_val, ts_test = ts_val_test.split("2013-02-28 23:00:00")
 
     # transform


### PR DESCRIPTION
按照官方文档来运行代码时，遇到了一点Bug：
1. 
```bash
Traceback (most recent call last):
  File "old.py", line 4, in <module>
    from paddlets.transform.normalization import StandardScaler
ModuleNotFoundError: No module named 'paddlets.transform.normalization'
```
这是因为该方法已经过时，应当为：
```bash
from paddlets.transform.sklearn_transforms import StandardScaler
```
2.
```bash
Traceback (most recent call last):
  File "old.py", line 11, in <module>
    ts_train, ts_val_test = ts.split("2012-03-31 23:00:00")
NameError: name 'ts' is not defined
```
这是因为变量名字不一致，应当为：
```bash
ts_train, ts_val_test = tsdataset.split("2012-03-31 23:00:00")
```
解决完上述问题后，代码可以正常运行。
此PR关联 Issue [https://github.com/PaddlePaddle/PaddleTS/issues/231](url)。