### PR TITLE
nbeats model's num_blocks param can specify the number of blocks per stack separately.

### DIFF
--- a/paddlets/tests/models/forecasting/dl/test_nbeats.py
+++ b/paddlets/tests/models/forecasting/dl/test_nbeats.py
@@ -174,6 +174,8 @@ class TestNBeatsModel(TestCase):
         reg = NBEATSModel(
             in_chunk_len = 7 * 96 + 9 * 4,
             out_chunk_len = 96,
+            generic_architecture = False,
+            num_blocks = [2, 4],
             skip_chunk_len = 15 * 4,
             eval_metrics = ["mse", "mae"],
             layer_widths = [64, 64]


### PR DESCRIPTION
Just like `layer_widths` param.

If a list is passed, it must have a length equal to `num_stacks` and every entry in that list corresponds to the corresponding stack. 

If an integer is passed, every stack will have the same number of blocks.