### PR TITLE
Add Revin wrapper

### DIFF
--- a/paddlets/models/forecasting/dl/informer.py
+++ b/paddlets/models/forecasting/dl/informer.py
@@ -10,6 +10,7 @@ import paddle
 
 from paddlets.models.forecasting.dl._informer import MixedEmbedding, Informer
 from paddlets.models.forecasting.dl.paddle_base_impl import PaddleBaseModelImpl
+from paddlets.models.forecasting.dl.revin import revin_norm
 from paddlets.models.common.callbacks import Callback
 from paddlets.logger import raise_if_not
 from paddlets.datasets import TSDataset
@@ -225,6 +226,8 @@ class InformerModel(PaddleBaseModelImpl):
         num_decoder_layers: int = 1,
         activation: str = "relu",
         dropout_rate: float = 0.1,
+        use_revin: bool = False,
+        revin_params: Dict[str, Any] = dict(eps=1e-5, affine=True),
     ):
         self._start_token_len = start_token_len
         self._d_model = d_model
@@ -234,6 +237,9 @@ class InformerModel(PaddleBaseModelImpl):
         self._num_decoder_layers = num_decoder_layers
         self._activation = activation
         self._dropout_rate = dropout_rate
+        self._use_revin = use_revin
+        self._revin_params = revin_params
+
         super(InformerModel, self).__init__(
             in_chunk_len=in_chunk_len,
             out_chunk_len=out_chunk_len,
@@ -305,6 +311,7 @@ class InformerModel(PaddleBaseModelImpl):
         }
         return fit_params
         
+    @revin_norm
     def _init_network(self) -> paddle.nn.Layer:
         """Setup the network.
 

--- a/paddlets/models/forecasting/dl/revin.py
+++ b/paddlets/models/forecasting/dl/revin.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# File Name:     revin.py
+# Author:        Yangrun
+# Created Time:  2022-12-07  17:40
+# Last Modified: <none>-<none>
+
+from typing import Dict
+import functools
+import numpy as np
+import paddle
+from paddle import nn
+from paddlets.logger import raise_if_not, Logger
+from paddlets.models import BaseModel
+
+logger = Logger(__name__)
+
+
+class RevinWrapper(nn.Layer):
+    def __init__(self, base_net: nn.Layer, num_features: int, eps=1e-5, affine=True):
+        """
+        The paddlepaddle implementation of Reversible Instance Normalization for
+        Accurate Time-Series Forecasting against Distribution Shift (RevIN)
+
+        The RevIN (Reversible Instance Normalization) is a simple yet effective normalization method
+        to mitigating the negaitve effects of temporal distribution shift problem.
+
+        This method has been proved to be effective in improving the performance of various existing models.
+
+        @inproceedings{kim2021reversible,
+            title={Reversible Instance Normalization for Accurate Time-Series Forecasting against Distribution Shift},
+            author={Kim, Taesung and Kim, Jinhee and Tae, Yunwon and Park, Cheonbok and Choi, Jang-Ho and Choo, Jaegul},
+            booktitle = {International Conference on Learning Representations},
+            year= {2021},
+            url= {https://openreview.net/forum?id=cGDAkQo1C0p}
+            }
+
+        This code is based on the official Pytorch Implementation (https://github.com/ts-kim/RevIN)
+
+
+        Args:
+        base_net(nn.Layer): the base network
+        num_features (int): the number of features or channels
+        eps (float): a value added for numerical stability
+        affine (float): if True, RevIN has learnable affine parameters
+        """
+
+        super(RevinWrapper, self).__init__()
+        self._base_net = base_net
+        self.num_features = num_features
+        eps_buffer = paddle.to_tensor(np.array([eps]).astype(np.float32))
+        self.register_buffer("eps", eps_buffer, persistable=True)
+        self.affine = affine
+        if affine:
+            self._init_params()
+
+    def _init_params(self):
+        affine_weight = self.create_parameter([self.num_features],
+                                              default_initializer=nn.initializer.Constant(value=1.0),
+                                              dtype="float32")
+        self.add_parameter("affine_weight", affine_weight)
+        affine_bias = self.create_parameter([self.num_features],
+                                            default_initializer=nn.initializer.Constant(value=0.0),
+                                            dtype="float32")
+        self.add_parameter("affine_bias", affine_bias)
+
+    def _get_statistics(self, x):
+        dim2reduce = tuple(range(1, x.ndim-1))
+        self.mean = paddle.mean(x, axis=dim2reduce, keepdim=True).detach()
+        self.stdev = paddle.sqrt(paddle.var(x, axis=dim2reduce, keepdim=True, unbiased=False) + self.eps).detach()
+
+    def _normalize(self, x):
+        x = x - self.mean
+        x = x / self.stdev
+        if self.affine:
+            x = x * self.affine_weight
+            x = x + self.affine_bias
+        return x
+
+    def _denormalize(self, x):
+        x = x - self.affine_bias
+        x = x / (self.affine_weight + self.eps*self.eps)
+        if self.affine:
+            x = x * self.stdev
+            x = x + self.mean
+        return x
+
+    def forward(self, data: Dict[str, paddle.Tensor]):
+        """
+        The past_target is first normalizated by the revin and the fed into the base model
+        Args:
+        data(Dict[str, paddle.Tensor]): a dict specifies all kinds of input data
+        Returns:
+            predictions: output of RNN model, with shape [batch_size, out_chunk_len, target_dim]
+        """
+        past_target = data['past_target']
+        self._get_statistics(past_target)
+        data['past_target'] = self._normalize(past_target)
+        out = self._base_net(data)
+        raise_if_not(
+                isinstance(out, paddle.Tensor),
+                'RevIN only support forcasting schema'
+                )
+        out = self._denormalize(out)
+        return out
+
+
+def revin_norm(func):
+    @functools.wraps(func)
+    def wrapper(obj: BaseModel, *args, **kwargs):
+        """
+        The core logic. The base model is been wrappered by the RevinWrapper.
+        """
+        model = func(obj, *args, **kwargs)
+        if obj._use_revin:
+            logger.warning("Using reversible instance normalization (revin) to remove and restore the statistical information of a time-series instance")
+            model = RevinWrapper(model, obj._fit_params['target_dim'], **obj._revin_params)
+        return model
+    return wrapper

--- a/paddlets/tests/models/forecasting/dl/test_informer_revin.py
+++ b/paddlets/tests/models/forecasting/dl/test_informer_revin.py
@@ -1,0 +1,251 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+from unittest import TestCase
+import unittest
+import random
+
+import pandas as pd
+import numpy as np
+
+from paddlets.models.forecasting import InformerModel
+from paddlets.datasets import TimeSeries, TSDataset
+
+
+class TestInformer(TestCase):
+    def setUp(self):
+        """unittest function
+        """
+        np.random.seed(2022)
+        target1 = pd.Series(
+                np.random.randn(2000).astype(np.float32),
+                index=pd.date_range("2022-01-01", periods=2000, freq="15T"),
+                name="a") 
+        target2 = pd.DataFrame(
+                np.random.randn(2000, 2).astype(np.float32),
+                index=pd.date_range("2022-01-01", periods=2000, freq="15T"),
+                columns=["a1", "a2"])
+        observed_cov = pd.DataFrame(
+                np.random.randn(2000, 2).astype(np.float32),
+                index=pd.date_range("2022-01-01", periods=2000, freq="15T"),
+                columns=["b", "c"])
+        known_cov = pd.DataFrame(
+                np.random.randn(2500, 2).astype(np.float32),
+                index=pd.date_range("2022-01-01", periods=2500, freq="15T"),
+                columns=["b1", "c1"])
+        static_cov = {"f": 1.0, "g": 2.0}
+
+        # index为DatetimeIndex类型
+        self.tsdataset1 = TSDataset(
+            TimeSeries.load_from_dataframe(target1), 
+            TimeSeries.load_from_dataframe(observed_cov), 
+            TimeSeries.load_from_dataframe(known_cov), 
+            static_cov)
+        self.tsdataset2 = TSDataset(
+            TimeSeries.load_from_dataframe(target2), 
+            TimeSeries.load_from_dataframe(observed_cov), 
+            TimeSeries.load_from_dataframe(known_cov), 
+            static_cov)
+
+        # index为RangeIndex类型
+        index = pd.RangeIndex(0, 2000, 2)
+        index2 = pd.RangeIndex(0, 2500, 2)
+        target2 = target2.reset_index(drop=True).reindex(index)
+        observed_cov = observed_cov.reset_index(drop=True).reindex(index)
+        known_cov = known_cov.reset_index(drop=True).reindex(index2)
+        self.tsdataset3 = TSDataset(
+            TimeSeries.load_from_dataframe(target2, freq=index.step),
+            TimeSeries.load_from_dataframe(observed_cov, freq=index.step),
+            TimeSeries.load_from_dataframe(known_cov, freq=index2.step),
+            static_cov) 
+        super().setUp()
+
+    def test_init(self):
+        """unittest function
+        """
+        # case1 (训练集的target为非float类型. 视具体模型而定, 目前transformer模型不支持target为除float之外的类型)
+        informer = InformerModel(
+            in_chunk_len=96,
+            out_chunk_len=96,
+            d_model=8,
+            nhead=1,
+            num_encoder_layers=1,
+            num_decoder_layers=1,
+            ffn_channels=64,
+            batch_size=512,
+            max_epochs=1
+        )
+        tsdataset = self.tsdataset1.copy()
+        tsdataset.astype({"a": "int32"})
+        with self.assertRaises(ValueError):
+            informer.fit(tsdataset, tsdataset)
+
+        # case2 (in_chunk_len 小于 start_token_len)
+        informer = InformerModel(
+            in_chunk_len=96,
+            out_chunk_len=96,
+            start_token_len=100,
+            d_model=8,
+            nhead=1,
+            num_encoder_layers=1,
+            num_decoder_layers=1,
+            ffn_channels=64,
+            batch_size=512,
+            max_epochs=1
+        )
+        with self.assertRaises(ValueError):
+            informer.fit(self.tsdataset1, self.tsdataset1)
+
+    def test_fit(self):
+        """unittest function
+        """
+        # case1 (用户只传入训练集, log不显示评估指标, 达到最大epochs训练结束)
+        informer = InformerModel(
+            in_chunk_len=96,
+            out_chunk_len=96,
+            d_model=8,
+            nhead=1,
+            num_encoder_layers=1,
+            num_decoder_layers=1,
+            ffn_channels=64,
+            optimizer_params=dict(learning_rate=1e-1),
+            use_revin=True,
+            batch_size=512,
+            max_epochs=5,
+            patience=1,
+        )
+        informer.fit(self.tsdataset1)
+
+        # case2 (用户同时传入训练/评估集和, log显示评估指标, 同时early_stopping生效)
+        informer = InformerModel(
+            in_chunk_len=96,
+            out_chunk_len=96,
+            d_model=8,
+            nhead=1,
+            num_encoder_layers=1,
+            num_decoder_layers=1,
+            ffn_channels=64,
+            optimizer_params=dict(learning_rate=1e-1),
+            use_revin=True,
+            batch_size=512,
+            max_epochs=5,
+            patience=1,
+        )
+        informer.fit(self.tsdataset1, self.tsdataset1)
+
+        informer = InformerModel(
+            in_chunk_len=96,
+            out_chunk_len=96,
+            d_model=8,
+            nhead=1,
+            num_encoder_layers=1,
+            num_decoder_layers=1,
+            ffn_channels=64,
+            optimizer_params=dict(learning_rate=1e-1),
+            use_revin=True,
+            batch_size=512,
+            max_epochs=5,
+            patience=1,
+        )
+        informer.fit([self.tsdataset1, self.tsdataset1], self.tsdataset1)
+
+    def test_predict(self):
+        """unittest function
+        """
+        # case1 (index为DatetimeIndex的单变量预测)
+        informer = InformerModel(
+            in_chunk_len=96,
+            out_chunk_len=96,
+            d_model=8,
+            nhead=1,
+            num_encoder_layers=1,
+            num_decoder_layers=1,
+            ffn_channels=64,
+            use_revin=True,
+            batch_size=512,
+            max_epochs=1,
+        )
+        informer.fit(self.tsdataset1, self.tsdataset1)
+        res = informer.predict(self.tsdataset1)
+
+        self.assertIsInstance(res, TSDataset)
+        self.assertEqual(res.get_target().data.shape, (96, 1))
+
+        # case2 (index为DatetimeIndex的多变量预测)
+        informer.fit(self.tsdataset2, self.tsdataset2)
+        res = informer.predict(self.tsdataset2)
+        self.assertIsInstance(res, TSDataset)
+        self.assertEqual(res.get_target().data.shape, (96, 2))
+
+        # case3 (index为RangeIndex的多变量预测)
+        informer.fit(self.tsdataset3, self.tsdataset3)
+        res = informer.predict(self.tsdataset3)
+        self.assertIsInstance(res.get_target().data.index, pd.RangeIndex)
+        self.assertIsInstance(res, TSDataset)
+        self.assertEqual(res.get_target().data.shape, (96, 2))
+
+    def test_recursive_predict(self):
+        """unittest function
+        """
+        # case1 (单变量预测)
+        informer = InformerModel(
+            in_chunk_len=96,
+            out_chunk_len=96,
+            skip_chunk_len=16,
+            d_model=8,
+            nhead=1,
+            num_encoder_layers=1,
+            num_decoder_layers=1,
+            ffn_channels=64,
+            eval_metrics=["mse", "mae"],
+            use_revin=True,
+            batch_size=512,
+            max_epochs=1
+        )
+        informer.fit(self.tsdataset1, self.tsdataset1)
+        # not supported when skip_chunk_len > 0
+        with self.assertRaises(ValueError):
+            res = informer.recursive_predict(self.tsdataset1, 96)
+
+        informer = InformerModel(
+            in_chunk_len=96,
+            out_chunk_len=96,
+            skip_chunk_len=0,
+            d_model=8,
+            nhead=1,
+            num_encoder_layers=1,
+            num_decoder_layers=1,
+            ffn_channels=64,
+            use_revin=True,
+            eval_metrics=["mse", "mae"],
+            batch_size=512,
+            max_epochs=1
+        )
+        informer.fit(self.tsdataset1, self.tsdataset1)
+        # not supported when predict_lenth < 0
+        with self.assertRaises(ValueError):
+            res = informer.recursive_predict(self.tsdataset1, 0)
+        res = informer.recursive_predict(self.tsdataset1, 1100)
+        self.assertIsInstance(res, TSDataset)
+        self.assertEqual(res.get_target().data.shape, (1100, 1))
+
+        res = informer.recursive_predict(self.tsdataset1, 10)
+        self.assertIsInstance(res, TSDataset)
+        self.assertEqual(res.get_target().data.shape, (10, 1))
+
+        # case2 (多变量预测)
+        informer.fit(self.tsdataset2, self.tsdataset2)
+        res = informer.recursive_predict(self.tsdataset2, 200)
+        self.assertIsInstance(res, TSDataset)
+        self.assertEqual(res.get_target().data.shape, (200, 2))
+
+        # case3 (range Index)
+        informer.fit(self.tsdataset3, self.tsdataset3)
+        res = informer.recursive_predict(self.tsdataset3, 2500)
+        self.assertIsInstance(res, TSDataset)
+        self.assertEqual(res.get_target().data.shape, (2500, 2))
+ 
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/paddlets/tests/models/forecasting/dl/test_nbeats_revin.py
+++ b/paddlets/tests/models/forecasting/dl/test_nbeats_revin.py
@@ -1,0 +1,263 @@
+# !/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+from unittest import TestCase, mock
+import unittest
+from enum import Enum
+from typing import List, NewType, Tuple, Union
+
+import paddle
+import pandas as pd
+import numpy as np
+
+from paddlets.datasets import TimeSeries, TSDataset
+from paddlets.models.common.callbacks import Callback
+from paddlets.models.forecasting.dl.nbeats import (
+    NBEATSModel,
+    _TrendGenerator,
+    _SeasonalityGenerator,
+    _GType,
+    _Block,
+    _Stack
+)
+
+np.random.seed(2023)
+paddle.seed(0)
+
+        
+class TestTrendBlock(TestCase):
+    
+    def setUp(self):        
+        self.module = _Block
+        self.params = {"num_layers": 4,
+                       "layer_width": 64,
+                       "expansion_coefficient_dim": 3,
+                       "backcast_length": 96 * 7 + 9 * 4,
+                       "in_chunk_len": (96 *7 + 9*4) * 4 + 96 * 2,
+                       "target_length": 96,
+                       "target_dim": 2,
+                       "g_type": _GType.TREND
+                      }
+        self.data_input = [paddle.randn([64, 96 * 7 + 9 * 4, 2]),
+                          paddle.randn([64, 96 * 7 + 9 * 4, 2]),
+                          paddle.randn([64, 96, 2])]
+    def test(self):
+        model = self.module(**self.params)
+        ret1, ret2 = model(*self.data_input)
+        self.assertEqual(ret1.shape, [64, 708, 2])
+        self.assertEqual(ret2.shape, [64, 96, 2])
+        
+        
+class TestSeasonBlock(TestCase):
+    
+    def setUp(self):        
+        self.module = _Block
+        self.params = {"num_layers": 4,
+                       "layer_width": 64,
+                       "expansion_coefficient_dim": 3,
+                       "backcast_length": 96 * 7 + 9 * 4,
+                       "in_chunk_len": (96 *7 + 9*4) * 4 + 96 * 2,
+                       "target_length": 96,
+                       "target_dim": 2,
+                       "g_type": _GType.SEASONALITY
+                      }
+        self.data_input = [paddle.randn([64, 96 * 7 + 9 * 4, 2]),
+                          paddle.randn([64, 96 * 7 + 9 * 4, 2]),
+                          paddle.randn([64, 96, 2])]
+    def test(self):
+        model = self.module(**self.params)
+        ret1, ret2 = model(*self.data_input)
+        self.assertEqual(ret1.shape, [64, 708, 2])
+        self.assertEqual(ret2.shape, [64, 96, 2])   
+        
+        
+class TestTrendStack(TestCase):
+    
+    def setUp(self):        
+        self.module = _Stack
+        self.params = {"num_blocks": 3,
+                       "num_layers": 4,
+                       "layer_width": 64,
+                       "expansion_coefficient_dim": 3,
+                       "backcast_length": 96 * 7 + 9 * 4,
+                       "in_chunk_len": (96 *7 + 9*4) * 4 + 96 * 2,
+                       "target_length": 96,
+                       "target_dim": 2,
+                       "g_type": _GType.TREND,
+                      }
+        self.data_input = [paddle.randn([64, 96 * 7 + 9 * 4, 2]),
+                          paddle.randn([64, 96 * 7 + 9 * 4, 2]),
+                          paddle.randn([64, 96, 2])]
+    def test(self):
+        model = self.module(**self.params)
+        ret1, ret2 = model(*self.data_input)
+        self.assertEqual(ret1.shape, [64, 708, 2])
+        self.assertEqual(ret2.shape, [64, 96, 2])   
+        
+        
+class TestSeasonStack(TestCase):
+    
+    def setUp(self):        
+        self.module = _Stack
+        self.params = {"num_blocks": 3,
+                       "num_layers": 4,
+                       "layer_width": 64,
+                       "expansion_coefficient_dim": 3,
+                       "backcast_length": 96 * 7 + 9 * 4,
+                       "in_chunk_len": (96 *7 + 9*4) * 4 + 96 * 2,
+                       "target_length": 96,
+                       "target_dim": 2,
+                       "g_type": _GType.SEASONALITY,
+                      }
+        self.data_input = [paddle.randn([64, 96 * 7 + 9 * 4, 2]),
+                          paddle.randn([64, 96 * 7 + 9 * 4, 2]),
+                          paddle.randn([64, 96, 2])]
+    def test(self):
+        model = self.module(**self.params)
+        ret1, ret2 = model(*self.data_input)
+        self.assertEqual(ret1.shape, [64, 708, 2])
+        self.assertEqual(ret2.shape, [64, 96, 2])  
+        
+
+class TestNBeatsModel(TestCase):
+    def setUp(self):
+        target_single = TimeSeries.load_from_dataframe(
+            pd.Series(
+                np.random.randn(2000).astype(np.float32),
+                index=pd.date_range("2022-01-01", periods=2000, freq="15T"),
+                name="a"
+            ))
+        target_multi = TimeSeries.load_from_dataframe(
+            pd.DataFrame(
+                np.random.randn(2000, 2).astype(np.float32),
+                index=pd.date_range("2022-01-01", periods=2000, freq="15T"),
+                columns=["a1", "a2"]
+            ))
+        
+        observed_cov = TimeSeries.load_from_dataframe(
+            pd.DataFrame(
+                np.random.randn(2000, 3).astype(np.float32),
+                index=pd.date_range("2022-01-01", periods=2000, freq="15T"),
+                columns=["b1", "b2", "b3"]
+            ))
+        known_cov = TimeSeries.load_from_dataframe(
+            pd.DataFrame(
+                np.random.randn(2500, 2).astype(np.float32),
+                index=pd.date_range("2022-01-01", periods=2500, freq="15T"),
+                columns=["c1", "c2"]
+            ))
+        static_cov = {"f": 1.0, "g": 2.0}
+
+        int_target = TimeSeries.load_from_dataframe(
+            pd.Series(
+                np.random.randint(0, 10, 2000).astype(np.int32),
+                index=pd.date_range("2022-01-01", periods=2000, freq="15T"),
+                name="a"
+            ))
+        category_known_cov = TimeSeries.load_from_dataframe(
+            pd.DataFrame(
+                np.random.choice(["a", "b", "c"], [2500, 2]),
+                index=pd.date_range("2022-01-01", periods=2500, freq="15T"),
+                columns=["c1", "c2"]
+            ))
+
+
+        self.tsdataset1 = TSDataset(target_single, observed_cov, known_cov, static_cov)
+        self.tsdataset2 = TSDataset(target_multi, observed_cov, known_cov, static_cov)
+        self.tsdataset3 = TSDataset(target_single, None, None, None)
+        self.tsdataset4 = TSDataset(int_target, None, category_known_cov, None)
+
+        super().setUp()
+    
+    def test_fit(self):
+        # case1: trend & seasonality
+        reg = NBEATSModel(
+            in_chunk_len = 7 * 96 + 9 * 4,
+            out_chunk_len = 96,
+            generic_architecture = False,
+            num_blocks = [2, 4],
+            skip_chunk_len = 15 * 4,
+            eval_metrics = ["mse", "mae"],
+            layer_widths = [64, 64],
+            use_revin=True
+        )
+        reg.fit(self.tsdataset1)
+        reg.fit(self.tsdataset1, self.tsdataset1)
+
+        # case2: general architecture
+        reg = NBEATSModel(
+                in_chunk_len = 7 * 96 + 9 * 4,
+                out_chunk_len = 96,
+                generic_architecture = True,
+                skip_chunk_len = 15 * 4,
+                eval_metrics = ["mse", "mae"],
+                layer_widths = 64,
+                use_revin=True
+                )
+        reg.fit(self.tsdataset2, self.tsdataset2)
+
+        # case3: no observed covariates
+        reg = NBEATSModel(
+                in_chunk_len = 7 * 96 + 9 * 4,
+                out_chunk_len = 96,
+                generic_architecture = True,
+                skip_chunk_len = 15 * 4,
+                eval_metrics = ["mse", "mae"],
+                use_revin=True
+                )
+        reg.fit(self.tsdataset3, self.tsdataset3)
+
+        #case4: bad case, invalid dtypes
+        with self.assertRaises(ValueError):
+            reg = NBEATSModel(
+                in_chunk_len= 7 * 96 + 9 * 4,
+                out_chunk_len = 96,
+                generic_architecture = True,
+                skip_chunk_len=4 * 4,
+                eval_metrics=["mse", "mae"],
+                use_revin=True
+            )
+            reg.fit(self.tsdataset4, self.tsdataset4)
+
+        # case5: bad case, layer_widths invalid
+        with self.assertRaises(ValueError):
+            reg = NBEATSModel(
+                    in_chunk_len = 7 * 96 + 9 * 4,
+                    out_chunk_len = 96,
+                    generic_architecture = True,
+                    skip_chunk_len = 15 * 4,
+                    eval_metrics = ["mse", "mae"],
+                    layer_widths = [64, 64, 64]
+                    )
+            reg.fit(self.tsdataset3, self.tsdataset3)
+
+    def test_predict(self):
+        reg = NBEATSModel(
+            in_chunk_len = 7 * 96 + 9 * 4,
+            out_chunk_len = 96,
+            skip_chunk_len = 15 * 4,
+            eval_metrics = ["mse", "mae"],
+            use_revin=True
+        )
+        # case1: single target
+        reg.fit(self.tsdataset1, self.tsdataset1)
+        res = reg.predict(self.tsdataset1)
+        self.assertIsInstance(res, TSDataset)
+        self.assertEqual(res.get_target().data.shape, (96, 1))
+
+        reg = NBEATSModel(
+            in_chunk_len = 7 * 96 + 9 * 4,
+            out_chunk_len = 96,
+            skip_chunk_len = 15 * 4,
+            eval_metrics = ["mse", "mae"],
+            use_revin=True
+        )
+
+        # case2: multi-target
+        reg.fit(self.tsdataset2, self.tsdataset2)
+        res = reg.predict(self.tsdataset2)
+        self.assertIsInstance(res, TSDataset)
+        self.assertEqual(res.get_target().data.shape, (96, 2))
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
1. Add [RevIN](https://openreview.net/pdf?id=cGDAkQo1C0p) method through python decorator which is compatible with all existing forecasting methods (apart from the deeper).  
2. Add parameters for Informer and NBeats models to enable RevIN normalization.