### PR TITLE
[NPU] Update pandas requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # core
 numpy>=1.17.0, <=1.26.4
-pandas>=0.25.0, <=1.3.5
+pandas>=0.25.0, <=1.4.3
 scikit-learn>=0.24.1, <1.4.0
 chinese-calendar==1.8.0
 python-docx


### PR DESCRIPTION
更新 pandas 依赖至 1.4.3。

低于 1.4.3 的 pandas 会导致 np.numeric.dtype 为 None https://stackoverflow.com/a/71879536 ，该 API 被昇腾使用，从而导致 TimesNetAd 在NPU 上推理报错：
```text
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/numpy/core/getlimits.py", line 670, in __init__
    self.dtype = numeric.dtype(int_type)
TypeError: 'NoneType' object is not callable
```