### PR TITLE
Fix dependency version pins for Python 3.12 compatibility

### DIFF
--- a/paddlets/datasets/tsdataset.py
+++ b/paddlets/datasets/tsdataset.py
@@ -70,7 +70,7 @@ class TimeSeries(object):
         self._data = data
         self._freq = freq
         if isinstance(self.freq, str):
-            self._data = self._data.asfreq(self._freq, method='bfill')
+            self._data = self._data.asfreq(self._freq).bfill()
             self._freq = self._data.index.freqstr  # ValueError: cannot reindex from a duplicate axis
 
     @classmethod

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 # core
 numpy>=1.17.0, <=1.26.4
-pandas>=0.25.0, <=1.4.3
-scikit-learn>=0.24.1, <1.4.0
+pandas>=1.3.0
+scikit-learn>=0.24.1
 chinese-calendar==1.8.0
 python-docx
-matplotlib>=3.1.2, <=3.8.0
-PyWavelets>=1.1.0, <=1.3.0
+matplotlib>=3.1.2
+PyWavelets>=1.1.0
 statsmodels>=0.10.2
 scipy>=1.5.0
 tqdm


### PR DESCRIPTION
## Summary
- Relax upper bounds for `pandas`, `scikit-learn`, `matplotlib`, `PyWavelets` in `requirements.txt` to allow versions compatible with Python 3.12
- Replace deprecated `DataFrame.asfreq(method='bfill')` with `.asfreq().bfill()` (`method` parameter was removed in pandas 2.2)

## Test plan
- [x] Verified with `pip install --dry-run` in a Python 3.12 environment that all dependencies resolve successfully
- [ ] Run existing unit tests to ensure no regressions