### PR TITLE
Fix pandas 2.0 API removals in time feature generator

### DIFF
--- a/paddlets/transform/time_feature.py
+++ b/paddlets/transform/time_feature.py
@@ -139,7 +139,7 @@ def _cal_weekofyear(x: np.datetime64, ):
     Returns
         int: week of year
     """
-    return x.weekofyear / 51.0 - 0.5
+    return x.isocalendar().week / 51.0 - 0.5
 
 
 def _cal_holiday(x: np.datetime64, ):
@@ -337,7 +337,7 @@ class TimeFeatureGenerator(BaseTransform):
                 start=tf_kcov[time_col][-1],
                 freq=freq,
                 periods=self.extend_points + 1,
-                closed='right',
+                inclusive='right',
                 name=time_col).to_frame()
             tf_kcov = pd.concat([tf_kcov, extend_time])
         #Generate time index feature content

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # core
 numpy>=1.17.0, <=1.26.4
-pandas>=1.3.0
+pandas>=1.4
 scikit-learn>=0.24.1
 chinese-calendar==1.8.0
 python-docx


### PR DESCRIPTION
## Summary
- Replace `pd.date_range(closed=)` with `inclusive=` in `TimeFeatureGenerator.transform_one` (`closed` was removed in pandas 2.0)
- Replace `Timestamp.weekofyear` with `.isocalendar().week` in `_cal_weekofyear` (`.weekofyear`/`.week` removed in pandas 2.0)
- Bump pandas floor to `>=1.4` since `inclusive=` was added in 1.4

## Context
#564 relaxed the pandas upper bound (`<=1.4.3` → `>=1.3.0`), which lets pip install pandas 2.x on Python 3.10+. Training then crashes in `paddlets/transform/time_feature.py:336` with `TypeError: DatetimeArray._generate_range() got an unexpected keyword argument 'closed'`, affecting downstream ts_forecast models in PaddleX (Nonstationary, TiDE, TimesNet).

Verified both API replacements on pandas 1.4.0 (floor) and 2.2.3 (latest 2.x):
- `Timestamp.isocalendar().week` returns the correct ISO week number on both
- `pd.date_range(..., inclusive='right')` produces the expected range on both

## Test plan
- [ ] ts_forecast training on Python 3.10 with pandas 2.x (Nonstationary / TiDE / TimesNet) now succeeds
- [ ] ts_forecast training on Python 3.10 with pandas 1.4.x still works